### PR TITLE
Collections

### DIFF
--- a/.idea/omnia_atari.iml
+++ b/.idea/omnia_atari.iml
@@ -7,4 +7,7 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
 </module>

--- a/omnia_atari.py
+++ b/omnia_atari.py
@@ -1,16 +1,26 @@
+from operator import itemgetter
 import time
+import argparse
 from pathlib import Path
 
 from internetarchive import search_items, Item
 from requests.exceptions import ConnectTimeout
 from urllib3.exceptions import ConnectTimeoutError
 
-DESTINATION_FOLDER_PATH = Path.home() / "iadownloads"
-DESTINATION_FOLDER_PATH.mkdir(exist_ok=True)
+parser = argparse.ArgumentParser()
+
+parser.add_argument("root", help="Root folder for downloads")
+args = parser.parse_args()
+
+DESTINATION_FOLDER_ROOT = Path(args.root)
+DESTINATION_ITEMS_PATH = DESTINATION_FOLDER_ROOT / "items"
+DESTINATION_ITEMS_PATH.mkdir(exist_ok=True)
+DESTINATION_COLLECTIONS_PATH = DESTINATION_FOLDER_ROOT / "collections"
+DESTINATION_COLLECTIONS_PATH.mkdir(exist_ok=True)
 
 
 # This is my best guess to get all 8 bit Atari Binaries the Internet Archive has on offer.
-def download_for_glob(glob_pattern, search_results: search_items):
+def download_for_glob(glob_pattern, search_results):
     # This is imperfect to say the least but if we fail, pause a minute and check the list for uncompleted downloads
     # Also gross - since glob_pattern only supports a SINGLE glob, if I want to ONLY download the various binary formats
     # I need to do separate downloads for each :(
@@ -18,7 +28,7 @@ def download_for_glob(glob_pattern, search_results: search_items):
     for item in search_results.iter_as_items():
         while True:
             try:
-                item.download(verbose=True, glob_pattern=glob_pattern, retries=50, destdir=str(DESTINATION_FOLDER_PATH))
+                item.download(verbose=True, glob_pattern=glob_pattern, retries=50, destdir=str(DESTINATION_ITEMS_PATH))
             except ConnectTimeoutError:
                 print("If at first we don't succeed - START AGAIN! - urllib3 timeout.")
                 time.sleep(30)
@@ -35,3 +45,8 @@ download_for_glob("*.atr", search)
 download_for_glob("*.rom", search)
 download_for_glob("*.cas", search)
 download_for_glob("*.car", search)
+
+# Now that we've downloaded the giant bag of items,
+# Create symlinks for the collections each title is in
+# in the collections folder. Name the links by the
+# item's title.

--- a/omnia_atari.py
+++ b/omnia_atari.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import pathlib
 import time
 import argparse

--- a/omnia_atari.py
+++ b/omnia_atari.py
@@ -68,4 +68,4 @@ if __name__ == '__main__':
             collection_symlink_path.mkdir(exist_ok=True)
             print(f"Creating symbolic link from {current_item_path} to {collection_symlink_path}")
             if not collection_symlink_path.exists():
-                current_item_path.symlink_to(collection_symlink_path, target_is_directory=True)
+                current_item_path.symlink_to(collection_symlink_path

--- a/omnia_atari.py
+++ b/omnia_atari.py
@@ -69,4 +69,4 @@ if __name__ == '__main__':
             collection_symlink_path.mkdir(exist_ok=True)
             print(f"Creating symbolic link from {current_item_path} to {collection_symlink_path}")
             if not collection_symlink_path.exists():
-                current_item_path.symlink_to(collection_symlink_path
+                current_item_path.symlink_to(collection_symlink_path)

--- a/omnia_atari.py
+++ b/omnia_atari.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
             collection_folder_path.mkdir(exist_ok=True)
             slugified_title = slugify(current_item.metadata['title'])
             collection_symlink_path: pathlib.Path = collection_folder_path / slugified_title
-            collection_symlink_path.mkdir(exist_ok=True)
+            # collection_symlink_path.mkdir(exist_ok=True)
             print(f"Creating symbolic link from {current_item_path} to {collection_symlink_path}")
             if not collection_symlink_path.exists():
                 current_item_path.symlink_to(collection_symlink_path)

--- a/omnia_atari.py
+++ b/omnia_atari.py
@@ -1,4 +1,3 @@
-from operator import itemgetter
 import time
 import argparse
 from pathlib import Path
@@ -40,13 +39,30 @@ def download_for_glob(glob_pattern, search_results):
             break
 
 
+def perform_download(search):
+    download_for_glob("*.atr", search)
+    download_for_glob("*.rom", search)
+    download_for_glob("*.cas", search)
+    download_for_glob("*.car", search)
+
+
 search = search_items('a8b_')
-download_for_glob("*.atr", search)
-download_for_glob("*.rom", search)
-download_for_glob("*.cas", search)
-download_for_glob("*.car", search)
+
+# perform_download(search)
 
 # Now that we've downloaded the giant bag of items,
 # Create symlinks for the collections each title is in
 # in the collections folder. Name the links by the
 # item's title.
+
+item: Item
+for item in search.iter_as_items():
+    title = item.metadata['title']
+    collections = item.collection
+
+# Rather than doing the downloads in bulk what we should do
+# is cycle through the search results, looking for items with
+# matching files that we're interested in.
+# That way, we can download the files as well as capturing the
+# necessary bits of metadata we need to add them to their
+# respective collections in the download set.

--- a/omnia_atari.py
+++ b/omnia_atari.py
@@ -42,19 +42,18 @@ if __name__ == '__main__':
 
     search = search_items('a8b_')
 
-    # perform_download(search)
-
     current_item: Item
     for current_item in search.iter_as_items():
         item_files = get_item_files(current_item)
-        atari_files = find_atari_files(item_files)
+        atari_files: list = find_atari_files(item_files)
         if not atari_files:
             continue
 
-        print(f"atari_files: {atari_files}")
+        atari_files_flat = " ".join(atari_files)
+        print(f"atari_files: {atari_files_flat}")
 
         print(f"Downloading {current_item.identifier} to {destination_items_path}")
-        current_item.download(verbose=True, files=atari_files, destdir=str(destination_items_path), retries=3)
+        current_item.download(verbose=True, files=atari_files_flat, destdir=str(destination_items_path), retries=3)
         collection_ids = [
             collection.metadata['identifier']
             for collection in current_item.collection
@@ -68,4 +67,5 @@ if __name__ == '__main__':
             collection_symlink_path: pathlib.Path = collection_folder_path / slugified_title
             collection_symlink_path.mkdir(exist_ok=True)
             print(f"Creating symbolic link from {current_item_path} to {collection_symlink_path}")
-            current_item_path.symlink_to(collection_symlink_path, target_is_directory=True)
+            if not collection_symlink_path.exists():
+                current_item_path.symlink_to(collection_symlink_path, target_is_directory=True)

--- a/omnia_atari.py
+++ b/omnia_atari.py
@@ -66,7 +66,10 @@ if __name__ == '__main__':
             collection_folder_path.mkdir(exist_ok=True)
             slugified_title = slugify(current_item.metadata['title'])
             collection_symlink_path: pathlib.Path = collection_folder_path / slugified_title
-            # collection_symlink_path.mkdir(exist_ok=True)
             print(f"Creating symbolic link from {current_item_path} to {collection_symlink_path}")
             if not collection_symlink_path.exists():
-                current_item_path.symlink_to(collection_symlink_path)
+                for atari_file in atari_files:
+                    item_file_path: pathlib.Path = current_item_path / atari_file
+                    collection_file_path: pathlib.Path = collection_symlink_path / atari_file
+                    item_file_path.symlink_to(collection_file_path)
+

--- a/omnia_atari.py
+++ b/omnia_atari.py
@@ -64,12 +64,8 @@ if __name__ == '__main__':
         for collection_name in collection_ids:
             collection_folder_path: pathlib.Path = destination_collections_path / collection_name
             collection_folder_path.mkdir(exist_ok=True)
-            slugified_title = slugify(current_item.metadata['title'])
-            collection_symlink_path: pathlib.Path = collection_folder_path / slugified_title
-            print(f"Creating symbolic link from {current_item_path} to {collection_symlink_path}")
-            if not collection_symlink_path.exists():
-                for atari_file in atari_files:
-                    item_file_path: pathlib.Path = current_item_path / atari_file
-                    collection_file_path: pathlib.Path = collection_symlink_path / atari_file
-                    item_file_path.symlink_to(collection_file_path)
-
+            for atari_file in atari_files:
+                collection_item_path: pathlib.Path = collection_folder_path / atari_file
+                item_file_path: pathlib.Path = current_item_path / atari_file
+                print(f"Creating symlink from {item_file_path} to {collection_folder_path}")
+                collection_item_path.symlink_to(item_file_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ internetarchive
 bs4
 requests
 urllib3
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ bs4
 requests
 urllib3
 pytest
+python-slugify

--- a/test_omnia.py
+++ b/test_omnia.py
@@ -1,0 +1,39 @@
+import omnia_atari
+
+
+def test_find_atari_files():
+    test_files = [
+        'DigDug.atr',
+        'BogusRandomThing.png',
+        'Mugwump.txt',
+        'Moof.room',
+        'Moof.rom',
+        'ObviouslyNotAtari.exe',
+        'this.xexis.moo'
+
+    ]
+
+    assert omnia_atari.find_atari_files(test_files) == [
+        'DigDug.atr',
+        'Moof.rom',
+    ]
+
+
+# THIS IS ENTIRELY WRONG. I guess I need to mock out all the internetarchive API objects? -CAP
+#
+# def test_get_item_files():
+#     fake_item_files = [{'name': 'BP4kgXMeRjGVbPTkRfQ3g_thumb_a8b_archive.torrent',
+#                         'source': 'metadata',
+#                         'btih': '8ae6ff804ba1dbd76321fa92ced0533e972963a4',
+#                         'mtime': '1613248077',
+#                         'size': '2170',
+#                         'md5': 'd35fca8e48203e68313468d918340a85',
+#                         'crc32': 'bea74742',
+#                         'sha1': 'a03e07fb1caed3ce34ee87c6d961207cdaf4db36',
+#                         'format': 'Archive BitTorrent'},
+#                        {'name': 'BP4kgXMeRjGVbPTkRfQ3g_thumb_a8b_files.xml',
+#                         'source': 'original',
+#                         'format': 'Metadata',
+#                         'md5': '6ba5d3e8bf5a324c51f5202e664876bd'}]
+#     assert omnia_atari.get_item_files(fake_item_files) == ['BP4kgXMeRjGVbPTkRfQ3g_thumb_a8b_archive.torrent',
+#                                                            'BP4kgXMeRjGVbPTkRfQ3g_thumb_a8b_files.xml']


### PR DESCRIPTION
Rather than just presenting a giant morass of numbered item directories to the user, symlink JUST the Atari executable files (disk, cartridge or cassette file) into whichever collections folder that item belongs to - e.g. games, applications, educational etc.